### PR TITLE
Add game played to item description

### DIFF
--- a/TwitchRSS/twitchrss.py
+++ b/TwitchRSS/twitchrss.py
@@ -177,6 +177,8 @@ class RSSVoDServer(webapp2.RequestHandler):
                         item["category"] = vod['broadcast_type']
                     item["link"] = link
                     item["description"] = "<a href=\"%s\"><img src=\"%s\" /></a>" % (link, vod['preview']['large'])
+                    if vod.get('game'):
+                        item["description"] += "<br/>" + vod['game']
                     if vod.get('description_html'):
                         item["description"] += "<br/>" + vod['description_html']
                     d = datetime.datetime.strptime(vod['created_at'], '%Y-%m-%dT%H:%M:%SZ')


### PR DESCRIPTION
Having the title of the game played somewhere in the RSS item is useful (at least to me).

This is a bit of a hack since the feed formatting library used doesn't have support for multiple category elements (the rss spec is okay with it).