### PR TITLE
Fix displaying thumbnails for live streams and optional "clearer" LIV…

### DIFF
--- a/TwitchRSS/twitchrss.py
+++ b/TwitchRSS/twitchrss.py
@@ -174,14 +174,13 @@ def construct_rss(channel_name, vods_info, display_name, add_live=True):
 
                 # It seems if the thumbnail is empty then we are live?
                 # Tempted to go in and fix it for them since the source is leaked..
-                if vod["thumbnail_url"] == '':
+                if vod["thumbnail_url"] == "https://vod-secure.twitch.tv/_404/404_processing_%{width}x%{height}.png":
                     if not add_live:
                         continue
                     link = "https://www.twitch.tv/%s" % channel_name
-                    item["title"] = "%s - LIVE" % vod['title']
+                    item["title"] = "LIVE 🔴 - %s" % vod['title'] # optional emoji, I find it easier to distinguish. Also starting with "LIVE" is clearer for me
                     item["category"] = "live"
-                    item["description"] = "<a href=\"%s\">LIVE LINK</a>" % link
-                else:
+item["description"] = "<a href=\"%s\"><img src=\"%s\" /></a>" % (link, vod['thumbnail_url'].replace("https://vod-secure.twitch.tv/_404/404_processing_%{width}x%{height}.png", "https://static-cdn.jtvnw.net/previews-ttv/live_user_%s-512x288.jpg" % channel_name ))                else:
                     link = vod['url']
                     item["title"] = vod['title']
                     item["category"] = vod['type']


### PR DESCRIPTION
This fixes getting the correct URL for thumbnails and being able to display it, at least for me. I'm currently using Photon RSS (https://sr.ht/~ghost08/photon) to view it so it's a neat addition to have. It also for some reason fixes getting the correct URL for the livestream to be able to play it with streamlink, where it was previously failing for some reason. 
The LIVE status change is purely optional , I just find it much clearer to distinguish if the title starts with "LIVE", especially if it's a long title it might get cut, and cannot see if it's live or a vod. The emoji is also purely optional, and if using a terminal to view the feed it would require it to have emoji support.